### PR TITLE
Updated CLI version to latest install_requirements.sh

### DIFF
--- a/environment_setup/install_requirements.sh
+++ b/environment_setup/install_requirements.sh
@@ -1,3 +1,3 @@
 python --version
-pip install azure-cli==2.0.46
+pip install azure-cli==2.0.69
 pip install --upgrade azureml-sdk[cli]


### PR DESCRIPTION
Hi, 

Older version of CLI doesn't work in Azure DevOps pipeline build. CLI version must used be latest.


Thanks,
Amit